### PR TITLE
Bump bls-signatures-pod to 0.2.4

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,10 +14,10 @@ PODS:
   - AFNetworking/Serialization (3.2.1)
   - AFNetworking/UIKit (3.2.1):
     - AFNetworking/NSURLSession
-  - bls-signatures-pod (0.2.3)
+  - bls-signatures-pod (0.2.4)
   - DashSync (0.1.0):
     - AFNetworking (~> 3.0)
-    - bls-signatures-pod (= 0.2.3)
+    - bls-signatures-pod (= 0.2.4)
     - secp256k1_dash (= 0.1.2)
   - KVO-MVVM (0.5.1)
   - secp256k1_dash (0.1.2)
@@ -39,8 +39,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
-  bls-signatures-pod: 2548b1aea18e1fc9f2cf3783193931ec39961f12
-  DashSync: 88606da64771c7e346d7e018bac2d3d5199fbb1d
+  bls-signatures-pod: 37010863455881049f9aa80d8430226a74f727c1
+  DashSync: 2cd9dd9759360a1586dd9b8b967c9610dd60423c
   KVO-MVVM: 4df3afd1f7ebcb69735458b85db59c4271ada7c6
   secp256k1_dash: 7fdbc23e3e8a27d522ec211b874d97fb091c2b23
 


### PR DESCRIPTION
depends on https://github.com/dashevo/dashsync-iOS/pull/45