### PR TITLE
Add 'dw_' prefix for UIImage+Utils methods, remove 'imageWithTintColo…

### DIFF
--- a/DashWallet/DWPhoneWCSessionManager.m
+++ b/DashWallet/DWPhoneWCSessionManager.m
@@ -149,12 +149,12 @@
             }
             
             if (! image && req.data) {
-                image = [UIImage imageWithQRCodeData:req.data color:[CIColor colorWithRed:0.0 green:141.0/255.0 blue:228.0/255.0]];
+                image = [UIImage dw_imageWithQRCodeData:req.data color:[CIColor colorWithRed:0.0 green:141.0/255.0 blue:228.0/255.0]];
             }
 
-            UIImage *resizedImage = [image resize:CGSizeMake(150, 150) withInterpolationQuality:kCGInterpolationNone];
-            UIImage *overlayLogo = [[UIImage imageNamed:@"dashQROverlay"] resize:CGSizeMake(37.0, 37.0) withInterpolationQuality:kCGInterpolationMedium];
-            __unused UIImage *result = [resizedImage imageByMergingWithImage:overlayLogo];
+            UIImage *resizedImage = [image dw_resize:CGSizeMake(150, 150) withInterpolationQuality:kCGInterpolationNone];
+            UIImage *overlayLogo = [[UIImage imageNamed:@"dashQROverlay"] dw_resize:CGSizeMake(37.0, 37.0) withInterpolationQuality:kCGInterpolationMedium];
+            __unused UIImage *result = [resizedImage dw_imageByMergingWithImage:overlayLogo];
             // TODO: figure out if it's mistype below or styled QR-code is not used intentionally
 
             replyHandler(image ? @{AW_QR_CODE_BITS_KEY: UIImagePNGRepresentation(image)} : @{});
@@ -294,12 +294,12 @@
     }
 
     if (! image && req) {
-        image = [UIImage imageWithQRCodeData:req color:[CIColor colorWithRed:0.0 green:0.0 blue:0.0]];
+        image = [UIImage dw_imageWithQRCodeData:req color:[CIColor colorWithRed:0.0 green:0.0 blue:0.0]];
     }
     
-    UIImage *resizedImage = [image resize:CGSizeMake(150, 150) withInterpolationQuality:kCGInterpolationNone];
-    UIImage *overlayLogo = [[UIImage imageNamed:@"dashQROverlay"] resize:CGSizeMake(37.0, 37.0) withInterpolationQuality:kCGInterpolationMedium];
-    UIImage *result = [resizedImage imageByMergingWithImage:overlayLogo];
+    UIImage *resizedImage = [image dw_resize:CGSizeMake(150, 150) withInterpolationQuality:kCGInterpolationNone];
+    UIImage *overlayLogo = [[UIImage imageNamed:@"dashQROverlay"] dw_resize:CGSizeMake(37.0, 37.0) withInterpolationQuality:kCGInterpolationMedium];
+    UIImage *result = [resizedImage dw_imageByMergingWithImage:overlayLogo];
     
     return result;
 }

--- a/DashWallet/DWReceiveViewController.m
+++ b/DashWallet/DWReceiveViewController.m
@@ -71,7 +71,7 @@
     if (req.isValid) {
         if (! _qrImage) {
             _qrImage = [[UIImage imageWithData:[self.groupDefs objectForKey:APP_GROUP_QR_IMAGE_KEY]]
-                        resize:self.qrView.bounds.size withInterpolationQuality:kCGInterpolationNone];
+                        dw_resize:self.qrView.bounds.size withInterpolationQuality:kCGInterpolationNone];
         }
         
         self.qrView.image = _qrImage;
@@ -123,15 +123,15 @@
         }
         
         if (! image && req.data) {
-            image = [UIImage imageWithQRCodeData:req.data color:[CIColor colorWithRed:0.0 green:141.0/255.0 blue:228.0/255.0]];
+            image = [UIImage dw_imageWithQRCodeData:req.data color:[CIColor colorWithRed:0.0 green:141.0/255.0 blue:228.0/255.0]];
             CGSize holeSize = CGSizeMake(5.0, 5.0);
-            image = [image imageByCuttingHoleInCenterWithSize:holeSize];
+            image = [image dw_imageByCuttingHoleInCenterWithSize:holeSize];
         }
         
         UIImage *overlayLogo = [UIImage imageNamed:@"dashQROverlay"];
-        UIImage *resizedImage = [image resize:qrViewBounds withInterpolationQuality:kCGInterpolationNone];
+        UIImage *resizedImage = [image dw_resize:qrViewBounds withInterpolationQuality:kCGInterpolationNone];
 
-        self.qrImage = [resizedImage imageByMergingWithImage:overlayLogo];
+        self.qrImage = [resizedImage dw_imageByMergingWithImage:overlayLogo];
         
         if (req.amount == 0) {
             if (req.isValid) {

--- a/DashWallet/DWRootViewController.m
+++ b/DashWallet/DWRootViewController.m
@@ -396,7 +396,7 @@
                                                            else img = [UIImage imageNamed:@"wallpaper-default"];
                                                            
                                                            [self.blur removeFromSuperview];
-                                                           self.blur = [[UIImageView alloc] initWithImage:[img blurWithRadius:3]];
+                                                           self.blur = [[UIImageView alloc] initWithImage:[img dw_blurWithRadius:3]];
                                                            [keyWindow.subviews.lastObject addSubview:self.blur];
                                                        }];
     
@@ -1225,7 +1225,7 @@
                                          afterScreenUpdates:NO];
     UIImage *bgImg = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    UIImage *blurredBgImg = [bgImg blurWithRadius:3];
+    UIImage *blurredBgImg = [bgImg dw_blurWithRadius:3];
     
     // display the popup
     __weak BREventConfirmView *view =

--- a/DashWallet/UIImage+Utils.h
+++ b/DashWallet/UIImage+Utils.h
@@ -28,13 +28,12 @@
 
 @interface UIImage (Utils)
 
-+ (instancetype)imageWithQRCodeData:(NSData *)data color:(CIColor *)color;
++ (instancetype)dw_imageWithQRCodeData:(NSData *)data color:(CIColor *)color;
 
-- (UIImage *)resize:(CGSize)size withInterpolationQuality:(CGInterpolationQuality)quality;
-- (UIImage *)blurWithRadius:(CGFloat)radius;
-- (UIImage *)imageWithTintColor:(UIColor *)tintColor;
-- (UIImage *)imageByMergingWithImage:(UIImage *)secondImage;
-- (UIImage *)imageByMergingWithImage:(UIImage *)secondImage secondImageRect:(CGRect)secondImageRect;
-- (UIImage *)imageByCuttingHoleInCenterWithSize:(CGSize)holeSize;
+- (UIImage *)dw_resize:(CGSize)size withInterpolationQuality:(CGInterpolationQuality)quality;
+- (UIImage *)dw_blurWithRadius:(CGFloat)radius;
+- (UIImage *)dw_imageByMergingWithImage:(UIImage *)secondImage;
+- (UIImage *)dw_imageByMergingWithImage:(UIImage *)secondImage secondImageRect:(CGRect)secondImageRect;
+- (UIImage *)dw_imageByCuttingHoleInCenterWithSize:(CGSize)holeSize;
 
 @end

--- a/DashWallet/UIImage+Utils.m
+++ b/DashWallet/UIImage+Utils.m
@@ -28,7 +28,7 @@
 
 @implementation UIImage (Utils)
 
-+ (instancetype)imageWithQRCodeData:(NSData *)data color:(CIColor *)color
++ (instancetype)dw_imageWithQRCodeData:(NSData *)data color:(CIColor *)color
 {
     UIImage *image;
     CGImageRef cgImg;
@@ -66,7 +66,7 @@
     return image;
 }
 
-- (UIImage *)resize:(CGSize)size withInterpolationQuality:(CGInterpolationQuality)quality
+- (UIImage *)dw_resize:(CGSize)size withInterpolationQuality:(CGInterpolationQuality)quality
 {
     UIGraphicsBeginImageContext(size);
     
@@ -85,7 +85,7 @@
     return image;
 }
 
-- (UIImage *)blurWithRadius:(CGFloat)radius
+- (UIImage *)dw_blurWithRadius:(CGFloat)radius
 {
     UIGraphicsBeginImageContext(self.size);
     
@@ -144,38 +144,16 @@
     return image;
 }
 
-- (UIImage *)imageWithTintColor:(UIColor *)tintColor
-{
-    UIGraphicsBeginImageContextWithOptions(self.size, NO, [UIScreen mainScreen].scale);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    CGContextTranslateCTM(context, 0, self.size.height);
-    CGContextScaleCTM(context, 1.0, -1.0);
-    CGRect rect = CGRectMake(0, 0, self.size.width, self.size.height);
-    
-    CGContextSetBlendMode(context, kCGBlendModeNormal);
-    CGContextDrawImage(context, rect, self.CGImage);
-    CGContextSetBlendMode(context, kCGBlendModeSourceIn);
-    [tintColor setFill];
-    CGContextFillRect(context, rect);
-    
-    
-    UIImage *coloredImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    return coloredImage;
-}
-
-- (UIImage *)imageByMergingWithImage:(UIImage *)secondImage {
+- (UIImage *)dw_imageByMergingWithImage:(UIImage *)secondImage {
     CGRect r = CGRectMake(roundf((self.size.width - secondImage.size.width) / 2.0),
                           roundf((self.size.height - secondImage.size.height) / 2.0),
                           secondImage.size.width,
                           secondImage.size.height);
     
-    return [self imageByMergingWithImage:secondImage secondImageRect:r];
+    return [self dw_imageByMergingWithImage:secondImage secondImageRect:r];
 }
 
-- (UIImage *)imageByMergingWithImage:(UIImage *)secondImage secondImageRect:(CGRect)secondImageRect {
+- (UIImage *)dw_imageByMergingWithImage:(UIImage *)secondImage secondImageRect:(CGRect)secondImageRect {
     UIImage *firstImage = self;
     CGSize imageSize = self.size;
     UIGraphicsBeginImageContextWithOptions(imageSize, NO, [UIScreen mainScreen].scale);
@@ -188,7 +166,7 @@
     return result;
 }
 
-- (UIImage *)imageByCuttingHoleInCenterWithSize:(CGSize)holeSize {
+- (UIImage *)dw_imageByCuttingHoleInCenterWithSize:(CGSize)holeSize {
     CGSize size = self.size;
     CGPoint centerPoint = CGPointMake((size.width - holeSize.width) / 2.0, (size.height - holeSize.height) / 2.0);
     

--- a/TodayExtension/BRTodayViewController.m
+++ b/TodayExtension/BRTodayViewController.m
@@ -120,9 +120,9 @@
     if (self.qrCodeData && self.qrImage.bounds.size.width > 0) {
         NSData *imageData = [self.appGroupUserDefault objectForKey:APP_GROUP_QR_IMAGE_KEY];
         UIImage *image = [UIImage imageWithData:imageData];
-        UIImage *resizedImage = [image resize:CGSizeMake(240, 240) withInterpolationQuality:kCGInterpolationNone];
+        UIImage *resizedImage = [image dw_resize:CGSizeMake(240, 240) withInterpolationQuality:kCGInterpolationNone];
         UIImage *overlayLogo = [UIImage imageNamed:@"dashQROverlay"];
-        UIImage *result = [resizedImage imageByMergingWithImage:overlayLogo];
+        UIImage *result = [resizedImage dw_imageByMergingWithImage:overlayLogo];
 
         self.qrOverlay.image = result;
         self.qrImage.image = result;


### PR DESCRIPTION
…r:' (it is available in DashSync)

depends on https://github.com/dashevo/dashsync-iOS/pull/51

The issue with QR code was because we had a method with the same name in DashSync UIImage+DSUtils category: `imageWithQRCodeData:color:color:` it overrides DashWallet's implementation which sets the value for the `inputCorrectionLevel` to `M` but DashSync sets it to `L`:
https://github.com/dashevo/dashsync-iOS/pull/51/files#diff-add55ae4071b53a47193eaf0f922dba0L45