### PR TITLE
fix(wallet): hide unavailable account entry points

### DIFF
--- a/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
@@ -118,11 +118,10 @@ final class CrowdNodeModel {
     var primaryAddress: String? { crowdNode.primaryAddress }
 
     var portalItems: [CrowdNodePortalItem] {
-        let hasAccount = CrowdNode.shared.signUpState == .finished
         return CrowdNodePortalItem.allCases.filter { item in
             switch item {
             case .deposit, .onlineAccount:
-                return hasAccount
+                return false
             default:
                 return true
             }

--- a/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
+++ b/DashWallet/Sources/UI/CrowdNode/CrowdNodeModel.swift
@@ -117,7 +117,17 @@ final class CrowdNodeModel {
 
     var primaryAddress: String? { crowdNode.primaryAddress }
 
-    let portalItems: [CrowdNodePortalItem] = CrowdNodePortalItem.allCases
+    var portalItems: [CrowdNodePortalItem] {
+        let hasAccount = CrowdNode.shared.signUpState == .finished
+        return CrowdNodePortalItem.allCases.filter { item in
+            switch item {
+            case .deposit, .onlineAccount:
+                return hasAccount
+            default:
+                return true
+            }
+        }
+    }
     var withdrawalLimits: [Int] { [
         Int(prefs.crowdNodeWithdrawalLimitPerTx / kOneDash),
         Int(prefs.crowdNodeWithdrawalLimitPerHour / kOneDash),

--- a/DashWallet/Sources/UI/CrowdNode/Getting Started/GettingStartedViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Getting Started/GettingStartedViewController.swift
@@ -122,6 +122,13 @@ extension GettingStartedViewController {
         linkAccountLabel.text = NSLocalizedString("Link Existing Account", comment: "CrowdNode")
 
         refreshCreateAccountButton()
+
+        newAccountButton.isHidden = true
+        linkAccountButton.isHidden = true
+        subtitleLabel.text = NSLocalizedString(
+            "CrowdNode sign-up and deposits are temporarily unavailable.",
+            comment: "CrowdNode"
+        )
     }
 
     private func configureObservers() {

--- a/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift
+++ b/DashWallet/Sources/UI/CrowdNode/Portal/CrowdNodePortalViewController.swift
@@ -198,11 +198,12 @@ extension CrowdNodePortalController {
 
 extension CrowdNodePortalController : UITableViewDelegate, UITableViewDataSource {
     func numberOfSections(in tableView: UITableView) -> Int {
-        2
+        Int(ceil(Double(viewModel.portalItems.count) / 2.0))
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        2
+        let startIndex = section * 2
+        return max(0, min(2, viewModel.portalItems.count - startIndex))
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {

--- a/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
@@ -31,6 +31,10 @@ struct ExploreMenuScreen: View {
         DWEnvironment.sharedInstance().currentChain.isTestnet()
     }
 
+    private var hasCrowdNodeAccount: Bool {
+        CrowdNode.shared.signUpState == .finished
+    }
+
     init(vc: UINavigationController,
          showBackButton: Bool = true,
          onShowSendPayment: @escaping () -> Void,
@@ -84,14 +88,16 @@ struct ExploreMenuScreen: View {
                 )
                 .frame(minHeight: 56)
 
-                MenuItem(
-                    title: NSLocalizedString("Staking", comment: ""),
-                    subtitleView: AnyView(StakingSubtitle()),
-                    icon: .custom("image-menu-staking", maxHeight: 30),
-                    iconAlignment: .top,
-                    action: { showStaking() }
-                )
-                .frame(minHeight: 56)
+                if hasCrowdNodeAccount {
+                    MenuItem(
+                        title: NSLocalizedString("Staking", comment: ""),
+                        subtitleView: AnyView(StakingSubtitle()),
+                        icon: .custom("image-menu-staking", maxHeight: 30),
+                        iconAlignment: .top,
+                        action: { showStaking() }
+                    )
+                    .frame(minHeight: 56)
+                }
             }
             .padding(6)
             .background(Color.secondaryBackground)

--- a/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
+++ b/DashWallet/Sources/UI/Explore Dash/ExploreMenuScreen.swift
@@ -32,7 +32,8 @@ struct ExploreMenuScreen: View {
     }
 
     private var hasCrowdNodeAccount: Bool {
-        CrowdNode.shared.signUpState == .finished
+        let state = CrowdNode.shared.signUpState
+        return state == .finished || state == .linkedOnline
     }
 
     init(vc: UINavigationController,

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -716,6 +716,12 @@ extension HomeViewModel {
                 guard let type = ShortcutActionType(rawValue: number.intValue) else { return nil }
                 return ShortcutAction(type: type)
             }
+            .filter { action in
+                if action.type == .crowdNode {
+                    return CrowdNode.shared.signUpState == .finished
+                }
+                return true
+            }
             if items.count == maxShortcutsCount {
                 DispatchQueue.main.async {
                     self.shortcutItems = items

--- a/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
+++ b/DashWallet/Sources/UI/Home/Views/HomeViewModel.swift
@@ -718,7 +718,8 @@ extension HomeViewModel {
             }
             .filter { action in
                 if action.type == .crowdNode {
-                    return CrowdNode.shared.signUpState == .finished
+                    let state = CrowdNode.shared.signUpState
+                    return state == .finished || state == .linkedOnline
                 }
                 return true
             }

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
@@ -52,7 +52,8 @@ extension ShortcutActionType {
             .send, .scanToPay, .payToAddress,
             .coinbase, .uphold, .topper
         ]
-        if CrowdNode.shared.signUpState == .finished {
+        let state = CrowdNode.shared.signUpState
+        if state == .finished || state == .linkedOnline {
             actions.append(.crowdNode)
         }
         return actions

--- a/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
+++ b/DashWallet/Sources/UI/Home/Views/Shortcuts/Models/ShortcutAction.swift
@@ -46,11 +46,17 @@ enum ShortcutActionType: Int {
 
 extension ShortcutActionType {
     /// The 13 features available for shortcut bar customization
-    static let customizableActions: [ShortcutActionType] = [
-        .buySellDash, .explore, .spend, .atm, .receive,
-        .send, .scanToPay, .payToAddress,
-        .crowdNode, .coinbase, .uphold, .topper
-    ]
+    static var customizableActions: [ShortcutActionType] {
+        var actions: [ShortcutActionType] = [
+            .buySellDash, .explore, .spend, .atm, .receive,
+            .send, .scanToPay, .payToAddress,
+            .coinbase, .uphold, .topper
+        ]
+        if CrowdNode.shared.signUpState == .finished {
+            actions.append(.crowdNode)
+        }
+        return actions
+    }
 
     var icon: UIImage {
         switch self {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
CrowdNode sign-up, deposit, and related entry points should no longer be exposed in parts of the app where that functionality is temporarily unavailable. This change removes or hides those entry points so users only see actions that are currently supported.


## What was done?
- Hid the **Staking** item in Explore Dash unless the user has a linked CrowdNode account.
- Removed CrowdNode from customizable shortcut options when no linked account exists.
- Filtered previously saved custom shortcuts so a stale CrowdNode shortcut is not restored without an account.
- Updated CrowdNode portal items to always hide **Deposit** and **Online Account**, leaving only supported portal actions visible.
- Kept the portal table layout aligned with the filtered portalItems source.
- Updated the CrowdNode Getting Started screen to hide sign-up/link buttons and show a temporary unavailability message.


## How Has This Been Tested?
- Verified the code changes by reviewing all affected CrowdNode entry points and ensuring the filtering logic is applied at the source of truth.
- Confirmed the relevant Explore, Home shortcut, CrowdNode portal, and Getting Started flows now read from the updated visibility rules.
- Full app build / automated tests were not run in this pass.


## Breaking Changes
None.


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* CrowdNode sign-up and deposit features are temporarily unavailable and have been hidden from the user interface.
* CrowdNode-related menu items and shortcuts now appear only when an active account has been established.
* Updated the Explore Dash menu to conditionally display staking options based on account status.
* Updated UI messaging to inform users that sign-up services are temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->